### PR TITLE
Add support for multiple CUE Sheet files in a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ bin-release/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.
+
+# CUE Sheet and FLAC files
+*.cue
+*.flac

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # FlacCueSplit
 
-Uses shnsplit and cuetag.
+Split up CUE Sheets into multiple tracks.
 
-Ubuntu: `sudo apt-get install cuetools shntool`
+## Dependencies
 
+Uses [shnsplit](https://manpages.debian.org/testing/shntool/shnsplit.1.en.html) and [cuetag](http://manpages.org/cuetag).
 
-How to use script:
+Ubuntu: `sudo apt-get install shntool cuetools`
 
-`./flaccuesplit.sh path/to/directory`
+## Running Extraction
+
+How to use start extraction:
+
+`./flaccuesplit.sh path/to/directory/containing/cuesheet`
+
+## Cases Handled
+
+| Case                         | Action                                                      |
+| ---------------------------- | ----------------------------------------------------------- |
+| Single CUE / Single FLAC     | Process right away                                          |
+| Single CUE / Multiple FLAC   | Not Supported if CUE Sheet has more than one FILE command   |
+| Multiple CUE / Single FLAC   | Choose which CUE Sheet file to use                          |
+| Multiple CUE / Multiple FLAC | Create a folder per CUE Sheet, run Single CUE / Single FLAC |
+
+**Note**: For the Multiple CUE / Multiple FLAC case it will temporarily move the CUE and corresponding FLAC file to the new directory for processing. The files will be returned back to their original location upon completion.

--- a/flaccuesplit.sh
+++ b/flaccuesplit.sh
@@ -4,56 +4,118 @@
 # Escape sequeces to change the text colour
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 LBLUE='\033[1;34m'
 NC='\033[0m' # No Color
 
-printC() {
+# Print colourful messages
+printColour() {
     message=$1
     colour=$2
     echo -e "${colour}${message}${NC}"
 }
 
+# Print infomation messages
 printInfo() {
-    printC "$1" $LBLUE
+    printColour "$1" $LBLUE
 }
 
+# Print Success Messages
 printSuccess() {
-    printC "$1" $GREEN
+    printColour "$1" $GREEN
 }
 
+# Print Error Messages
 printError() {
-    printC "$1" $RED >&2
+    printColour "$1" $RED >&2
 }
 
+# Print Debug messages
+# Note the DEBUG variable must be set to true
+printDebug() {
+    if [ "$DEBUG" = true ]; then
+        printColour "$1" $YELLOW
+    fi
+}
+
+# Split CUE Sheet file
 flaccuesplit ()
 {
     cueFile="$1"
     flacFile="$2"
-    printInfo "Now Splitting Files"
+    
+    printInfo "Now Splitting Files from $cueFile"
+    
     shnsplit -f "$cueFile" -t %n-%t -o flac "$flacFile"
     if [ $? -ne 0 ]; then
         printError "Splitting Failed!"
         exit 1
     fi
+    
+    printSuccess "Success Splitting Files"
+
 }
 
+# Apply metadata to extracted files from the CUE Sheet file
 splitflacTag ()
 {
     cueFile="$1"
+    
+    printInfo "Tagging Files from $cueFile"
     cuetag "$cueFile" [0-9]*.flac
     printSuccess "Files Tagged"
 }
 
 printInfo "Starting flaccuesplit"
 
+# Save off the script and its base directory
+currentScriptName="$0"
+baseDir="$PWD"
+
+# Capture arguement and change to it
 path="$1"
 cd "$path"
 
+# Find out what CUE and FLAC files exist
 cueFile=(*.cue)
 flacFile=(*.flac)
 
-if [ ${#cueFile[@]} -gt 1 ]; then
+# By default don't skip processing
+skipProcessing=false
+
+if [ ${#cueFile[@]} -gt 1 -a ${#flacFile[@]} -gt 1 ]; then # Multiple CUE / Multiple FLAC
+    printInfo "Found Multiple CUE Sheet and Audio Files"
+    for INDEX in ${!cueFile[@]}; do
+        FILE="${cueFile[${INDEX}]}"
+        
+        printDebug "Current File $FILE"
+        
+        # Read the CUE Sheet for the corresponding FLAC file
+        # There might be multiple FILE commands in the CUE Sheet, so handle this as an array
+        readarray cueAudioFiles < <(grep FILE "$FILE" | sed -En 's/.*FILE "(.+)".*/\1/p')
+        if [ ${#cueAudioFiles[@]} -gt 1 ]; then
+            printError "SKIPPED: The CUE Sheet ($FILE) contains multiple FILE commands, this is not supported 😞"
+            continue
+        fi
+
+        # It is known there is only one audio file, grab its file name
+        cueAudioFile=$(echo "${cueAudioFiles[0]}" | xargs)
+
+        # Move the CUE and FLAC file to a new directory
+        fileNameWithoutExt=$(basename -s .cue "$FILE")
+        printInfo "Creating new directory for Album: $fileNameWithoutExt"        
+        mkdir -p "$fileNameWithoutExt"
+        mv "$FILE" "$cueAudioFile" "$fileNameWithoutExt"
+        
+        # Read flac file with this tool
+        eval "$baseDir/$currentScriptName \"$fileNameWithoutExt\""
+
+        # Move original files back to their original location
+        mv "$fileNameWithoutExt/$FILE" "$fileNameWithoutExt/$cueAudioFile" .
+    done
+    skipProcessing=true
+elif [ ${#cueFile[@]} -gt 1 ]; then # Multiple CUE / Single FLAC
     printInfo "Multiple CUE files found\nSelect one."
     for INDEX in ${!cueFile[@]}; do 
         echo "${INDEX}) ${cueFile[${INDEX}]}"
@@ -61,10 +123,14 @@ if [ ${#cueFile[@]} -gt 1 ]; then
     
     read -p "Enter the number of the file you want: " usrSelection 
     cueFile="${cueFile[${usrSelection}]}"
-else
+else # Single CUE / Single FLAC
     cueFile="${cueFile[0]}"
 fi
 
-flaccuesplit "$cueFile" "${flacFile[0]}"
+# Only process if processing isn't requested to be skipped
+if [ "$skipProcessing" != true ]; then 
+    flaccuesplit "$cueFile" "${flacFile[0]}"
 
-splitflacTag "$cueFile"
+    splitflacTag "$cueFile"
+    printSuccess "CUE file successfully processed"
+fi

--- a/flaccuesplit.sh
+++ b/flaccuesplit.sh
@@ -1,18 +1,39 @@
 #!/usr/bin/env bash
 
-echo "Starting flaccuesplit"
+# Colour Support
+# Escape sequeces to change the text colour
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+LBLUE='\033[1;34m'
+NC='\033[0m' # No Color
 
-path="$1"
-cd "$path"
+printC() {
+    message=$1
+    colour=$2
+    echo -e "${colour}${message}${NC}"
+}
+
+printInfo() {
+    printC "$1" $LBLUE
+}
+
+printSuccess() {
+    printC "$1" $GREEN
+}
+
+printError() {
+    printC "$1" $RED >&2
+}
 
 flaccuesplit ()
 {
     cueFile="$1"
     flacFile="$2"
-    echo "Now Splitting Files"
+    printInfo "Now Splitting Files"
     shnsplit -f "$cueFile" -t %n-%t -o flac "$flacFile"
     if [ $? -ne 0 ]; then
-        echo "Splitting Failed!"
+        printError "Splitting Failed!"
         exit 1
     fi
 }
@@ -21,14 +42,19 @@ splitflacTag ()
 {
     cueFile="$1"
     cuetag "$cueFile" [0-9]*.flac
-    echo "Files Tagged"
+    printSuccess "Files Tagged"
 }
+
+printInfo "Starting flaccuesplit"
+
+path="$1"
+cd "$path"
 
 cueFile=(*.cue)
 flacFile=(*.flac)
 
-if [ ${#cueFile[@]} -gt 1 ]; then 
-    echo -e "Multiple files found\nSelect one."
+if [ ${#cueFile[@]} -gt 1 ]; then
+    printInfo "Multiple CUE files found\nSelect one."
     for INDEX in ${!cueFile[@]}; do 
         echo "${INDEX}) ${cueFile[${INDEX}]}"
     done
@@ -38,7 +64,6 @@ if [ ${#cueFile[@]} -gt 1 ]; then
 else
     cueFile="${cueFile[0]}"
 fi
-
 
 flaccuesplit "$cueFile" "${flacFile[0]}"
 


### PR DESCRIPTION
The PR adds support for when there are multiple CUE Sheet files in a directory, each with their own corresponding audio file.

It doesn't handle CUE Sheets with more than one `FILE` command in them.

It also adds some pretty colours to the messages that are output.